### PR TITLE
Release/1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [1.5.0](https://github.com/dreamstechnology/dreams-web-sdk/compare/v1.4.1...v1.5.0) (2024-05-21)
+
+
+### Features
+
+* add callback urls to transfer consent requested event ([c2cd9f1](https://github.com/dreamstechnology/dreams-web-sdk/commit/c2cd9f1d8fe4e1f3190d1996a1042fa4718a750e))
+
+# [1.5.0](https://github.com/dreamstechnology/dreams-web-sdk/compare/v1.4.1...v1.5.0) (2024-05-21)
+
+
+### Features
+
+* add callback urls to transfer consent requested event ([c2cd9f1](https://github.com/dreamstechnology/dreams-web-sdk/commit/c2cd9f1d8fe4e1f3190d1996a1042fa4718a750e))
+
 ## [1.4.1](https://github.com/dreamstechnology/dreams-web-sdk/compare/v1.4.0...v1.4.1) (2023-08-09)
 
 # [1.4.0](https://github.com/dreamstechnology/dreams-web-sdk/compare/v1.3.0...v1.4.0) (2023-03-24)

--- a/release.config.js
+++ b/release.config.js
@@ -1,25 +1,29 @@
-const commitAnalyzer = ["@semantic-release/commit-analyzer", {
-  "preset": "angular",
-  "releaseRules": [
-    {"type": "docs", "scope":"readme", "release": "patch"},
-    {"type": "refactor", "release": "patch"},
-    {"type": "style", "release": "patch"},
-    {"type": "build", "release": "patch"}
-  ],
-  "parserOpts": {
-    "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
-  }
-}];
+const commitAnalyzer = [
+  '@semantic-release/commit-analyzer',
+  {
+    preset: 'angular',
+    releaseRules: [
+      { type: 'docs', scope: 'readme', release: 'patch' },
+      { type: 'refactor', release: 'patch' },
+      { type: 'style', release: 'patch' },
+      { type: 'build', release: 'patch' },
+    ],
+    parserOpts: {
+      noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
+    },
+  },
+];
 
 module.exports = {
   preset: 'angular',
   branches: ['main'],
+  repositoryUrl: 'git@github.com:dreamstechnology/dreams-web-sdk.git',
   plugins: [
     commitAnalyzer,
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
     '@semantic-release/github',
     '@semantic-release/git',
-    '@semantic-release/npm'
+    '@semantic-release/npm',
   ],
 };


### PR DESCRIPTION
The release was done manually. This PR contains:
- changelog generated by semantic-release
- and minor changes to config (changing git link from http to ssh), required by semantic release 